### PR TITLE
feat: supports archive pickup

### DIFF
--- a/app/graphql/queries/contents_query.rb
+++ b/app/graphql/queries/contents_query.rb
@@ -12,10 +12,7 @@ module Queries
         result = result.order(since: :asc, until: :asc)
         result = result.where(until: until_after..) if until_after.present?
         result = result.where(since: ...since_before) if since_before.present?
-        if content_ids.present?
-          content_id_key = model.name.underscore + "_id"
-          result = result.where(**{content_id_key => content_ids})
-        end
+        result = result.where(uid: content_ids) if content_ids.present?
         result
       end.flatten.sort_by do |content|
         [content.since, content.until]

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -30,6 +30,7 @@ module Types
 
     field :type, EventTypeEnum, null: false
     field :rerun, Boolean, null: false
+    field :endless, Boolean, null: false
     field :image_url, String, null: true
     field :videos, [VideoType], null: false
     field :pickups, [Types::PickupType], null: false

--- a/app/graphql/types/pickup_type.rb
+++ b/app/graphql/types/pickup_type.rb
@@ -22,6 +22,6 @@ module Types
     field :student_name, String, null: false
     field :event, "Types::EventType", null: false
     field :since, GraphQL::Types::ISO8601DateTime, null: false
-    field :until, GraphQL::Types::ISO8601DateTime, null: false
+    field :until, GraphQL::Types::ISO8601DateTime, null: true
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,7 +3,7 @@ class Event < ApplicationRecord
 
   EVENT_TYPES = [
     "event", "mini_event", "guide_mission", "immortal_event",
-    "pickup", "fes", "campaign", "exercise", "main_story", "collab",
+    "pickup", "archive_pickup", "fes", "campaign", "exercise", "main_story", "collab",
   ].freeze
 
   validates :type, inclusion: { in: EVENT_TYPES }

--- a/app/models/pickup.rb
+++ b/app/models/pickup.rb
@@ -1,12 +1,22 @@
 class Pickup < ApplicationRecord
-  PICKUP_TYPES = ["usual", "limited", "given", "fes"].freeze
+  PICKUP_TYPES = ["usual", "limited", "given", "fes", "archive"].freeze
 
   belongs_to :event, primary_key: :uid, foreign_key: :event_uid
   belongs_to :student, primary_key: :uid, foreign_key: :student_uid, optional: true
 
+  before_validation :fill_student, on: :create
   validates :pickup_type, inclusion: { in: PICKUP_TYPES }
 
   alias_attribute :type, :pickup_type
 
   def student_name = student&.name || fallback_student_name
+
+  private
+
+  def fill_student
+    return if student.present?
+    return if fallback_student_name.blank?
+
+    self.student = Student.find_by(name: fallback_student_name)
+  end
 end

--- a/db/migrate/20250723152220_add_endless_to_events.rb
+++ b/db/migrate/20250723152220_add_endless_to_events.rb
@@ -1,0 +1,6 @@
+class AddEndlessToEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :events, :endless, :boolean, default: false, null: false
+    change_column_null :pickups, :until, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_25_104113) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_23_152220) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -28,6 +28,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_25_104113) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "event_index"
+    t.boolean "endless", default: false, null: false
   end
 
   create_table "pickups", force: :cascade do |t|
@@ -36,7 +37,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_25_104113) do
     t.string "event_uid", null: false
     t.string "pickup_type", null: false
     t.datetime "since", null: false
-    t.datetime "until", null: false
+    t.datetime "until"
     t.boolean "rerun", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/graphql/queries/contents_query_spec.rb
+++ b/spec/graphql/queries/contents_query_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Contents Query", type: :graphql do
+  describe "contents query" do
+    let!(:event1) { FactoryBot.create(:event, uid: "event-1", since: 5.weeks.ago, until: 4.weeks.ago) }
+    let!(:event2) { FactoryBot.create(:event, uid: "event-2", since: 3.weeks.ago, until: 2.weeks.ago) }
+    let!(:raid1) { FactoryBot.create(:raid, uid: "raid-1", since: 2.weeks.ago, until: 1.week.ago) }
+    let!(:raid2) { FactoryBot.create(:raid, uid: "raid-2", since: 1.week.from_now, until: 2.weeks.from_now) }
+
+    query = <<~GRAPHQL
+      query($untilAfter: ISO8601DateTime, $sinceBefore: ISO8601DateTime, $contentIds: [String!]) {
+        contents(untilAfter: $untilAfter, sinceBefore: $sinceBefore, contentIds: $contentIds) {
+          edges {
+            node {
+              uid name
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    let(:variables) { {} }
+
+    subject { execute_graphql(query, variables: variables)["data"]["contents"]["edges"].map { |edge| edge["node"] } }
+
+    context "when no arguments are provided" do
+      it "returns all contents" do
+        expect(subject.map { |node| node["uid"] }).to eq(["event-1", "event-2", "raid-1", "raid-2"])
+      end
+    end
+
+    context "when untilAfter is provided" do
+      let(:variables) { { untilAfter: 10.days.ago.iso8601 } }
+
+      it "returns contents until the provided time" do
+        expect(subject.map { |node| node["uid"] }).to eq(["raid-1", "raid-2"])
+      end
+    end
+
+    context "when sinceBefore is provided" do
+      let(:variables) { { sinceBefore: 2.weeks.ago.iso8601 } }
+
+      it "returns contents since the provided time" do
+        expect(subject.map { |node| node["uid"] }).to eq(["event-1", "event-2"])
+      end
+    end
+
+    context "when contentIds is provided" do
+      let(:variables) { { contentIds: ["event-1", "raid-1"] } }
+
+      it "returns contents with the provided IDs" do
+        expect(subject.map { |node| node["uid"] }).to eq(["event-1", "raid-1"])
+      end
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Event, type: :model do
     let(:event) { FactoryBot.create(:event) }
 
     before do
+      FactoryBot.create(:student, uid: "10089", name: "아루(드레스)")
+      
       FactoryBot.create(:pickup, event: event, student_uid: "10089")
       FactoryBot.create(:pickup, event: event, fallback_student_name: "카요코(드레스)")
-
-      FactoryBot.create(:student, uid: "10089", name: "아루(드레스)")
     end
 
     subject { event.pickups }

--- a/spec/models/pickup_spec.rb
+++ b/spec/models/pickup_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe Pickup, type: :model do
+  describe "#fill_student" do
+    subject { pickup.save! }
+
+    let(:pickup) { FactoryBot.build(:pickup, student_uid: nil, fallback_student_name: fallback_student_name) }
+
+    context "when student is already present" do
+      let(:pickup) { FactoryBot.build(:pickup, student_uid: "13005", fallback_student_name: "카요코") }
+
+      before do
+        FactoryBot.create(:student, uid: "13005", name: "카요코")
+      end
+
+      it "does not change the student" do
+        expect { subject }.not_to change { pickup.student_uid }
+      end
+    end
+
+    context "when fallback_student_name is blank" do
+      let(:fallback_student_name) { "" }
+
+      it "does not set a student" do
+        expect { subject }.not_to change { pickup.student_uid }
+      end
+    end
+
+    context "when fallback_student_name matches an existing student" do
+      let(:fallback_student_name) { "카요코" }
+
+      before do
+        FactoryBot.create(:student, uid: "13005", name: "카요코")
+      end
+
+      it "sets the student_uid to the matching student" do
+        expect { subject }.to change { pickup.student_uid }.from(nil).to("13005")
+      end
+    end
+
+    context "when fallback_student_name does not match any existing student" do
+      let(:fallback_student_name) { "미쿠" }
+
+      it "does not set a student" do
+        expect { subject }.not_to change { pickup.student_uid }
+      end
+    end
+  end
+
+  describe "#student_name" do
+    subject { pickup.student_name }
+
+    context "when student is present" do
+      let(:pickup) { FactoryBot.build(:pickup, student_uid: "13005", fallback_student_name: "카요코") }
+
+      before do
+        FactoryBot.create(:student, uid: "13005", name: "카요코2")
+      end
+
+      it "returns the student name" do
+        expect(subject).to eq("카요코2")
+      end
+    end
+
+    context "when student is not present" do
+      let(:pickup) { FactoryBot.build(:pickup, student_uid: nil, fallback_student_name: "카요코") }
+
+      it "returns the fallback student name" do
+        expect(subject).to eq("카요코")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request supports archive pickup.

- Added event/pickup type
- There is no end date for archive pickups. So set the `until` field as nullable for the Pickup model, and added a `endless` field to the Event model.